### PR TITLE
introduce append_readme parameter to enhance workspace DESCRIPTION element

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AnVILPublish
 Title: Publish Packages and Other Resources to AnVIL Workspaces
-Version: 1.1.0
+Version: 1.1.0-1
 Authors@R: 
     person(
         given = "Martin",

--- a/R/as_workspace.R
+++ b/R/as_workspace.R
@@ -144,6 +144,11 @@
 #'     to create a workspace is run but no output generated; this can
 #'     be useful during debugging.
 #'
+#' @param append_readme logical(1) Defaults to `FALSE`; if `TRUE` the content
+#'     of README.md in package top-level folder is ingested and appended
+#'     to the package `DESCRIPTION` version and provenance metadata for rendering in
+#'     the workspace "DESCRIPTION".
+#'
 #' @return `as_workspace()` returns the URL of the updated workspace,
 #'     invisibly.
 #'
@@ -151,7 +156,8 @@
 #'
 #' @export
 as_workspace <-
-    function(path, namespace, name = NULL, create = FALSE, update = FALSE)
+    function(path, namespace, name = NULL, create = FALSE, update = FALSE,
+      append_readme=FALSE)
 {
     stopifnot(
         .is_scalar_character(path), dir.exists(path),
@@ -185,6 +191,14 @@ as_workspace <-
 
     tmpl <- .template("dashboard.tmpl")
     dashboard <- whisker.render(tmpl, data)
+    
+    if (append_readme) {
+      rmepath = paste(path, "/README.md", sep="")
+      stopifnot(file.exists(rmepath))
+      rme = paste(readLines(rmepath), collapse="\n")
+      dashboard = paste(dashboard, rme, collapse="\n")
+      }
+
     !(create || update) || .set_dashboard(dashboard, namespace, name)
 
     ## create setup notebook

--- a/man/as_workspace.Rd
+++ b/man/as_workspace.Rd
@@ -4,7 +4,14 @@
 \alias{as_workspace}
 \title{Render R packages as AnVIL workspaces}
 \usage{
-as_workspace(path, namespace, name = NULL, create = FALSE, update = FALSE)
+as_workspace(
+  path,
+  namespace,
+  name = NULL,
+  create = FALSE,
+  update = FALSE,
+  append_readme = FALSE
+)
 }
 \arguments{
 \item{path}{\code{character(1)} path to the location of the package
@@ -25,6 +32,11 @@ DASHBOARD and any similarly named notebooks) an existing
 workspace?  If niether \code{create} nore \code{update} is TRUE, the code
 to create a workspace is run but no output generated; this can
 be useful during debugging.}
+
+\item{append_readme}{logical(1) Defaults to \code{FALSE}; if \code{TRUE} the content
+of README.md in package top-level folder is ingested and appended
+to the package \code{DESCRIPTION} version and provenance metadata for rendering in
+the workspace "DESCRIPTION".}
 }
 \value{
 \code{as_workspace()} returns the URL of the updated workspace,


### PR DESCRIPTION
Passes check ... I do not see how to propagate image information, but it is not important.  The provenance
information is doublespaced and consumes a bit too much screenspace IMHO but I have not addressed this.