### PR TITLE
Changes to allow .qmd files to be copied to terra

### DIFF
--- a/R/as_notebook.R
+++ b/R/as_notebook.R
@@ -165,7 +165,7 @@
 #'     *ipynb`.
 #'
 #' @param type `character(1)` The type of notebook to be in the
-#'     workspace. Must be on of `ipynb`, `rmd`, or `both`.
+#'     workspace. Must be one of `ipynb`, `rmd`, `qmd`, or `all`.
 #'
 #' @param quarto `character(1)` If the program Quarto is installed, this
 #'     parameter indicates whether the .Rmd files will be rendered or converted.
@@ -178,7 +178,7 @@
 as_notebook <-
     function(
         rmd_paths, namespace, name, update = FALSE,
-        type = c('ipynb', 'rmd', 'both'),
+        type = c('ipynb', 'rmd', 'qmd', 'all'),
         quarto = c('render', 'convert'))
 {
     type = match.arg(type)
@@ -191,7 +191,7 @@ as_notebook <-
     )
 
     notebooks <- character(0)
-    if (type %in% c('ipynb', 'both')) {
+    if (type %in% c('ipynb', 'all')) {
         if (.quarto_exists()) {
             notebooks <- .rmd_to_quarto(rmd_paths, quarto)
         } else {
@@ -199,8 +199,14 @@ as_notebook <-
             notebooks <- .md_to_ipynb(mds)
         }
     }
-    if (type %in% c('rmd', 'both')) {
+    if (type %in% c('rmd', 'all')) {
         notebooks <- c(notebooks, rmd_paths)
+    }
+
+    vignette_path <- dirname(rmd_paths)[1]
+    qmd_paths <- dir(vignette_path, pattern = "\\.[Qq]md$", full.names = TRUE)
+    if (type %in% c('qmd', 'all')) {
+        notebooks <- c(notebooks, qmd_paths)
     }
 
     if (update) {

--- a/R/as_workspace.R
+++ b/R/as_workspace.R
@@ -186,7 +186,7 @@
 #'     rendering in the workspace 'DASHBOARD'.
 #'
 #' @param type `character(1)` The type of notebook to be in the
-#'     workspace. Must be one of `ipynb`, `rmd`, or `both`.
+#'     workspace. Must be one of `ipynb`, `rmd`, `qmd`, or `all`.
 #'
 #' @param quarto `character(1)` If the program Quarto is installed, this
 #'     parameter indicates whether the .Rmd files will be rendered or converted.
@@ -200,7 +200,7 @@
 #' @export
 as_workspace <-
     function(path, namespace, name = NULL, create = FALSE, update = FALSE,
-             use_readme = FALSE, type = c('ipynb', 'rmd', 'both'),
+             use_readme = FALSE, type = c('ipynb', 'rmd', 'qmd', 'all'),
              quarto = c('render', 'convert'))
 {
     type = match.arg(type)


### PR DESCRIPTION
This code copies .qmd files over to Terra. They don't appear in the Analyses tab like .Rmd and .ipynb file would, but they are present under Data/Files/notebooks. Since there are three options to copy over now I didn't know how you wanted to handle multiple combinations so I just went with 'ipynb', 'rmd', 'qmd', and 'all'. I did test this using my previously created test anvil workspace, `as_workspace('~/AnVILBulkRNASeq', namespace = 'bioconductor-rpci-anvil', name = 'test-quarto', create = FALSE, update = TRUE, type = 'all', quarto = 'convert')`. In order for this to work I created .qmd files for each of the vignettes, that way there were actual .qmd files to copy over.