### PR TITLE
Move README section into template

### DIFF
--- a/R/as_workspace.R
+++ b/R/as_workspace.R
@@ -249,13 +249,13 @@ as_workspace <-
     data$name <- name
 
     tmpl <- .template("dashboard.tmpl")
-    dashboard <- whisker.render(tmpl, data)
 
     if (use_readme) {
         rmepath <- file.path(path, "README.md")
-        rme <- paste(readLines(rmepath), collapse="\n")
-        dashboard <- paste(dashboard, rme, collapse="\n")
+        data$README <- paste(readLines(rmepath), collapse="\n")
     }
+
+    dashboard <- whisker.render(tmpl, data)
 
     !(create || update) || .set_dashboard(dashboard, namespace, name)
 

--- a/inst/template/dashboard.tmpl
+++ b/inst/template/dashboard.tmpl
@@ -18,7 +18,8 @@ Author: {{ #Authors }}
 Maintainer:
 - {{{ Maintainer }}}
 
-License: {{{ License }}}
+License: {{{ License }}} {{ #URL }}
+URL: {{{ URL }}} {{ /URL }}
 
 # Notebook setup
 

--- a/inst/template/dashboard.tmpl
+++ b/inst/template/dashboard.tmpl
@@ -1,40 +1,42 @@
-# {{{ Title }}}
+{{ #README }}
+# README
+{{{ README }}} {{ /README }}
 
-{{{ Description }}}
+# R Package DESCRIPTION
 
-Author:
-{{ #Authors }}
-- {{{ Author }}}{{ /Authors }}
+Package: {{{ Package }}}
 
-Maintainer:
-
-- {{{ Maintainer }}}
-
-Source package: {{{ Package }}}
-
-Licence: {{{ License }}}
+Title: {{{ Title }}}
 
 Version: {{{ Version }}}
 
-## Notebook setup
+Description: {{{ Description }}}
+
+Author: {{ #Authors }}
+- {{{ Author }}} {{ /Authors }}
+
+Maintainer:
+- {{{ Maintainer }}}
+
+License: {{{ License }}}
+
+# Notebook setup
 
 - Use the '00-{{{ name }}}' notebook to configure your runtime for
   this workspace.
 
-## Vignettes
+# Vignettes
 
 {{ #Vignettes }}
 {{#ipynb}}[ipynb](https://anvil.terra.bio/#workspaces/{{{ namespace }}}/{{{ name }}}/analysis/launch/{{{ ipynb }}}) {{/ipynb}}{{!
 }}{{#rmd}}[Rmd](https://anvil.terra.bio/#workspaces/{{{ namespace }}}/{{{ name }}}/analysis/launch/{{{ rmd }}}){{/rmd}} -- {{{ title }}}
 {{ #vignette_authors }}
-- {{{ name }}} {{#email}}(<a href="mailto:{{{email}}}">{{{email}}}</a>){{/email}} {{ /vignette_authors }}
-{{ /Vignettes }}
+- {{{ name }}} {{#email}}(<a href="mailto:{{{email}}}">{{{email}}}</a>){{/email}} {{ /vignette_authors }} {{ /Vignettes }}
 
-## Citation
+# Citation
 
 {{{ Citation }}}
 
 R version {{{ RVersion }}}, Bioconductor version {{{ BioconductorVersion }}}
 
 Workspace dashboard created: {{{ ProcessDate }}}
-

--- a/inst/template/dashboard.tmpl
+++ b/inst/template/dashboard.tmpl
@@ -4,22 +4,23 @@
 
 # R Package DESCRIPTION
 
-Package: {{{ Package }}}
+**Package**: {{{ Package }}}
 
-Title: {{{ Title }}}
+**Title**: {{{ Title }}}
 
-Version: {{{ Version }}}
+**Version**: {{{ Version }}}
 
-Description: {{{ Description }}}
+**Description**: {{{ Description }}}
 
-Author: {{ #Authors }}
+**Author**: {{ #Authors }}
 - {{{ Author }}} {{ /Authors }}
 
-Maintainer:
+**Maintainer**:
 - {{{ Maintainer }}}
 
-License: {{{ License }}} {{ #URL }}
-URL: {{{ URL }}} {{ /URL }}
+**License**: {{{ License }}} {{ #URL }}
+
+**URL**: {{{ URL }}} {{ /URL }}
 
 # Notebook setup
 


### PR DESCRIPTION
Hi @vjcitn 
I updated the template to include the `README` section at the top of the dashboard. By adding this section to the template, it will get added in `whisker.render` automatically, if / when available.

Here is a working example: https://anvil.terra.bio/#workspaces/waldronlab-terra/BiocPkg-curatedENCORE-copy